### PR TITLE
feat: enhance channel management by adding username to channel details and updating response structures

### DIFF
--- a/internal/database/queries/channel.sql
+++ b/internal/database/queries/channel.sql
@@ -14,14 +14,24 @@ ORDER BY
     c.id DESC;
 
 -- name: GetChannelByID :one
-SELECT *
-FROM channels
-WHERE id = ?;
+SELECT
+    c.id,
+    c.name,
+    c.description,
+    c.created_by,
+    u.username AS created_by_username,
+    c.created_at
+FROM
+    channels AS c
+INNER JOIN
+    users AS u ON u.id = c.created_by
+WHERE
+    c.id = ?;
 
 -- name: CreateChannel :one
 INSERT INTO channels (name, description, created_by)
 VALUES (?, ?, ?)
-RETURNING *;
+RETURNING id;
 
 -- name: DeleteChannel :exec
 DELETE FROM channels

--- a/internal/handlers/channel_handler_test.go
+++ b/internal/handlers/channel_handler_test.go
@@ -340,7 +340,7 @@ func setupSuccessfulChannelDeletion(t *testing.T) (*handlers.Handler, int64, int
 		t.Fatalf(failedCreateTestUser, err)
 	}
 
-	channel, err := queries.CreateChannel(context.Background(), repository.CreateChannelParams{
+	chId, err := queries.CreateChannel(context.Background(), repository.CreateChannelParams{
 		Name:        "todelete",
 		Description: sql.NullString{String: "Channel to delete", Valid: true},
 		CreatedBy:   user.ID,
@@ -350,7 +350,7 @@ func setupSuccessfulChannelDeletion(t *testing.T) (*handlers.Handler, int64, int
 	}
 
 	h := handlers.NewHandler(getMockLogger(), queries)
-	return h, channel.ID, user.ID, func() { db.Close() }
+	return h, chId, user.ID, func() { db.Close() }
 }
 
 func setupChannelNotFound(t *testing.T) (*handlers.Handler, int64, int64, func()) {
@@ -389,7 +389,7 @@ func setupUserNotOwner(t *testing.T) (*handlers.Handler, int64, int64, func()) {
 		t.Fatalf("Failed to create not-owner user: %v", err)
 	}
 
-	channel, err := queries.CreateChannel(context.Background(), repository.CreateChannelParams{
+	chId, err := queries.CreateChannel(context.Background(), repository.CreateChannelParams{
 		Name:        "ownedchannel",
 		Description: sql.NullString{String: "Channel owned by first user", Valid: true},
 		CreatedBy:   owner.ID,
@@ -399,7 +399,7 @@ func setupUserNotOwner(t *testing.T) (*handlers.Handler, int64, int64, func()) {
 	}
 
 	h := handlers.NewHandler(getMockLogger(), queries)
-	return h, channel.ID, notOwner.ID, func() { db.Close() }
+	return h, chId, notOwner.ID, func() { db.Close() }
 }
 
 func setupBasicHandler(t *testing.T) (*handlers.Handler, int64, int64, func()) {


### PR DESCRIPTION
This pull request refactors the channel creation and retrieval logic to improve data consistency and API response quality. The main change is that the channel creation now returns only the channel ID, and a subsequent query fetches the full channel details, including the creator's username. This affects SQL queries, repository methods, handler functions, and related tests.

**Database and Repository Changes**
* The `CreateChannel` SQL statement and repository method now return only the channel ID instead of the full channel record. [[1]](diffhunk://#diff-56b5586596841fc51df43db05ff159531f406a7926379a040836a7bdf51a24d5L17-R34) [[2]](diffhunk://#diff-43dcad4b8af8c6680b8ca0999465b1fb3a5f0c95f7a231301301e13feddd44b3L17-R17) [[3]](diffhunk://#diff-43dcad4b8af8c6680b8ca0999465b1fb3a5f0c95f7a231301301e13feddd44b3L26-R30)
* The `GetChannelByID` query now joins the `users` table to include the creator's username, and the corresponding repository method returns a new `GetChannelByIDRow` struct with this data. [[1]](diffhunk://#diff-56b5586596841fc51df43db05ff159531f406a7926379a040836a7bdf51a24d5L17-R34) [[2]](diffhunk://#diff-43dcad4b8af8c6680b8ca0999465b1fb3a5f0c95f7a231301301e13feddd44b3L110-R136)

**Handler Changes**
* The channel creation handler now performs two queries: it first creates the channel and retrieves the ID, then fetches the full channel details for the response.
* The response struct and helper function are updated to use the new `GetChannelByIDRow` type and always include the creator's username. [[1]](diffhunk://#diff-24fd9408f69bbff90cbf0591f3312e23153c10e4b34d6454f8b7992767a09f3aL37-R37) [[2]](diffhunk://#diff-24fd9408f69bbff90cbf0591f3312e23153c10e4b34d6454f8b7992767a09f3aL46-R46) [[3]](diffhunk://#diff-24fd9408f69bbff90cbf0591f3312e23153c10e4b34d6454f8b7992767a09f3aL56-R62)

**Test Updates**
* Channel creation in tests is updated to expect and use only the channel ID, not the full record. Helper functions and assertions are refactored accordingly. [[1]](diffhunk://#diff-971dc04953e8c9f8dbf193951bf18960eaa216b817947e9022578dde0f581292L275-R275) [[2]](diffhunk://#diff-971dc04953e8c9f8dbf193951bf18960eaa216b817947e9022578dde0f581292L285-R285) [[3]](diffhunk://#diff-971dc04953e8c9f8dbf193951bf18960eaa216b817947e9022578dde0f581292L305-R308) [[4]](diffhunk://#diff-971dc04953e8c9f8dbf193951bf18960eaa216b817947e9022578dde0f581292L328-R337) [[5]](diffhunk://#diff-971dc04953e8c9f8dbf193951bf18960eaa216b817947e9022578dde0f581292L355-L374) [[6]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L343-R343) [[7]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L353-R353) [[8]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L392-R392) [[9]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L402-R402)