### PR TITLE
Feature/health check

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: self-hosted
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
+    - name: Update docker-compose.yml on VM
+      run: |
+        cp docker-compose.yml ${{ secrets.OLHA_MENSAGEM_DIRECTORY_VM }}/docker-compose.yml
+    
     - name: Backup current deployment
       run: |
         set -euo pipefail
@@ -36,3 +40,21 @@ jobs:
           docker compose up -d --force-recreate
           exit 1
         fi
+
+    - name: Wait for application to be healthy
+      run: |
+        set -euo pipefail
+        cd ${{ secrets.OLHA_MENSAGEM_DIRECTORY_VM }}
+        echo "Waiting for application to be healthy..."
+        for i in {1..12}; do
+          if docker compose ps app | grep -q "healthy"; then
+            echo "Application is healthy!"
+            exit 0
+          fi
+          echo "Attempt $i/12: Application not ready yet, waiting 5 seconds..."
+          sleep 5
+        done
+        echo "Application failed to become healthy within 60 seconds, rolling back..."
+        docker tag fortega21/olha-mensagem-app:backup fortega21/olha-mensagem-app:latest || true
+        docker compose up -d --force-recreate
+        exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -trimpath -buildvcs=false -ldflags="-s -w" -o /out/main ./cmd/real-time-chat
 
 FROM alpine:3.22
-RUN apk add --no-cache ca-certificates sqlite-libs tzdata \
+RUN apk add --no-cache ca-certificates curl sqlite-libs tzdata \
     && addgroup -S app && adduser -S -G app app \
     && mkdir -p /olha-mensagem-app/data && chown app:app /olha-mensagem-app/data
 WORKDIR /olha-mensagem-app
@@ -40,4 +40,8 @@ ENV PORT=8080 \
     MESSAGES_LIMIT=150
 EXPOSE 8080
 USER app
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -fsS --max-time 8 http://localhost:${PORT}/health || exit 1
+
 CMD ["/olha-mensagem-app/main"]

--- a/cmd/real-time-chat/main.go
+++ b/cmd/real-time-chat/main.go
@@ -38,7 +38,7 @@ func main() {
 	}()
 
 	queries := repository.New(db.GetDB())
-	srv := server.NewServer(logger, queries)
+	srv := server.NewServer(logger, queries, db.GetDB())
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,6 +53,12 @@ services:
       - "traefik.http.routers.app-dev.rule=Host(`localhost`) || Host(`olhamensagem.localhost`)"
       - "traefik.http.routers.app-dev.entrypoints=web"
       - "traefik.http.services.app-dev.loadbalancer.server.port=8081"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8081/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     restart: unless-stopped
     networks:
       - app-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,19 @@ services:
       - "traefik.http.services.app.loadbalancer.server.port=8080"
       - "traefik.http.routers.app.middlewares=security-headers"
       - "traefik.http.middlewares.security-headers.headers.customrequestheaders.X-Forwarded-Proto=https"
+      - "traefik.http.middlewares.security-headers.headers.customrequestheaders.X-Content-Type-Options=nosniff"
+      - "traefik.http.middlewares.security-headers.headers.customrequestheaders.X-Frame-Options=DENY"
+      - "traefik.http.middlewares.security-headers.headers.customrequestheaders.X-XSS-Protection=1; mode=block"
       - "traefik.http.middlewares.security-headers.headers.sslredirect=true"
       - "traefik.http.middlewares.security-headers.headers.stsSeconds=31536000"
       - "traefik.http.middlewares.security-headers.headers.stsIncludeSubdomains=true"
       - "traefik.http.middlewares.security-headers.headers.stsPreload=true"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     restart: unless-stopped
     networks:
       - app-network

--- a/internal/dto/health_check_dto.go
+++ b/internal/dto/health_check_dto.go
@@ -1,12 +1,19 @@
 package dto
 
+type HealthStatus string
+
+const (
+	HealthStatusHealthy   HealthStatus = "healthy"
+	HealthStatusUnhealthy HealthStatus = "unhealthy"
+)
+
 type HealthCheckResponseDTO struct {
-	Status  string `json:"status"`
-	Error   string `json:"error,omitempty"`
-	Version string `json:"version"`
+	Status  HealthStatus `json:"status"`
+	Error   string       `json:"error,omitempty"`
+	Version string       `json:"version"`
 }
 
-func NewHealthCheckResponse(status, version string, err error) HealthCheckResponseDTO {
+func NewHealthCheckResponse(status HealthStatus, version string, err error) HealthCheckResponseDTO {
 	health := HealthCheckResponseDTO{
 		Status:  status,
 		Version: version,

--- a/internal/dto/health_check_dto.go
+++ b/internal/dto/health_check_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+type HealthCheckResponseDTO struct {
+	Status  string `json:"status"`
+	Error   string `json:"error,omitempty"`
+	Version string `json:"version"`
+}
+
+func NewHealthCheckResponse(status, version string, err error) HealthCheckResponseDTO {
+	health := HealthCheckResponseDTO{
+		Status:  status,
+		Version: version,
+	}
+	if err != nil {
+		health.Error = err.Error()
+	}
+	return health
+}

--- a/internal/handlers/channel_handler_test.go
+++ b/internal/handlers/channel_handler_test.go
@@ -37,7 +37,7 @@ func TestGetAllChannels(t *testing.T) {
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
 				queries := repository.New(db)
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			expectedStatus: http.StatusOK,
@@ -102,7 +102,7 @@ func TestCreateChannel(t *testing.T) {
 					t.Fatalf(failedCreateTestUser, err)
 				}
 
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "general", "description": "General discussion", "userId": int64(1)},
@@ -112,7 +112,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "Empty Channel Name",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "", "description": "Empty name test", "userId": int64(1)},
@@ -122,7 +122,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "Invalid User ID - Zero",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "test", "description": testChannelDesc, "userId": int64(0)},
@@ -132,7 +132,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "Missing User ID",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "test", "description": testChannelDesc},
@@ -142,7 +142,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "Invalid JSON",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        "invalid-json",
@@ -152,7 +152,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "User Does Not Exist",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "test", "description": testChannelDesc, "userId": int64(999)},
@@ -172,7 +172,7 @@ func TestCreateChannel(t *testing.T) {
 					t.Fatalf(failedCreateTestUser, err)
 				}
 
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]interface{}{"name": "random", "userId": int64(1)},
@@ -182,7 +182,7 @@ func TestCreateChannel(t *testing.T) {
 			name: "User Does Not Exist",
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithChannels(t)
-				h := handlers.NewHandler(getMockLogger(), repository.New(db))
+				h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 				return h, func() { db.Close() }
 			},
 			payload:        map[string]any{"name": "test", "description": testChannelDesc, "userId": int64(999)},
@@ -223,7 +223,7 @@ func TestCreateChannel(t *testing.T) {
 func TestCreateChannelInvalidJSONSyntax(t *testing.T) {
 	db := initializeTestDBWithChannels(t)
 	defer db.Close()
-	h := handlers.NewHandler(getMockLogger(), repository.New(db))
+	h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 
 	req := httptest.NewRequest(http.MethodPost, pathChannels, bytes.NewBufferString("{"))
 	req.Header.Set(headerContentType, mimeApplicationJSON)
@@ -243,7 +243,7 @@ func TestCreateChannelInvalidJSONSyntax(t *testing.T) {
 func TestCreateChannelMissingUserID(t *testing.T) {
 	db := initializeTestDBWithChannels(t)
 	defer db.Close()
-	h := handlers.NewHandler(getMockLogger(), repository.New(db))
+	h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 
 	payload := map[string]string{"name": "test", "description": testChannelDesc}
 	body, _ := json.Marshal(payload)
@@ -349,7 +349,7 @@ func setupSuccessfulChannelDeletion(t *testing.T) (*handlers.Handler, int64, int
 		t.Fatalf("Failed to create test channel: %v", err)
 	}
 
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 	return h, chId, user.ID, func() { db.Close() }
 }
 
@@ -365,7 +365,7 @@ func setupChannelNotFound(t *testing.T) (*handlers.Handler, int64, int64, func()
 		t.Fatalf(failedCreateTestUser, err)
 	}
 
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 	return h, 9999, user.ID, func() { db.Close() }
 }
 
@@ -398,13 +398,13 @@ func setupUserNotOwner(t *testing.T) (*handlers.Handler, int64, int64, func()) {
 		t.Fatalf("Failed to create test channel: %v", err)
 	}
 
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 	return h, chId, notOwner.ID, func() { db.Close() }
 }
 
 func setupBasicHandler(t *testing.T) (*handlers.Handler, int64, int64, func()) {
 	db := initializeTestDBWithChannels(t)
-	h := handlers.NewHandler(getMockLogger(), repository.New(db))
+	h := handlers.NewHandler(getMockLogger(), repository.New(db), db)
 	return h, 0, 0, func() { db.Close() }
 }
 
@@ -503,7 +503,7 @@ func setupChannelTest(t *testing.T) (*sql.DB, *handlers.Handler) {
 	db := initializeTestDBWithChannels(t)
 
 	queries := repository.New(db)
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 
 	user, err := queries.CreateUser(context.Background(), repository.CreateUserParams{
 		Username: "channeltestuser",

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"database/sql"
+
 	"github.com/fortega2/real-time-chat/internal/logger"
 	"github.com/fortega2/real-time-chat/internal/repository"
 )
@@ -17,16 +19,20 @@ const (
 	failedEncodeDeleteChannelRspErrMsg = "Failed to encode delete channel response"
 
 	failedEncodeMessageDataErrMsg = "Failed to encode message data"
+
+	failedEncodeHealthCheckErrMsg = "Failed to encode health check response"
 )
 
 type Handler struct {
 	logger  logger.Logger
 	queries *repository.Queries
+	db      *sql.DB
 }
 
-func NewHandler(l logger.Logger, q *repository.Queries) *Handler {
+func NewHandler(l logger.Logger, q *repository.Queries, db *sql.DB) *Handler {
 	return &Handler{
 		logger:  l,
 		queries: q,
+		db:      db,
 	}
 }

--- a/internal/handlers/health_check_handler.go
+++ b/internal/handlers/health_check_handler.go
@@ -17,12 +17,12 @@ func (h *Handler) HealthCheck(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.db.PingContext(ctx); err != nil {
 		h.logger.Error("Database ping failed", "error", err)
-		respondWithJSON(w, http.StatusServiceUnavailable, dto.NewHealthCheckResponse("unhealthy", getVersion(), err), failedEncodeHealthCheckErrMsg)
+		respondWithJSON(w, http.StatusServiceUnavailable, dto.NewHealthCheckResponse(dto.HealthStatusUnhealthy, getVersion(), err), failedEncodeHealthCheckErrMsg)
 		return
 	}
 
-	respondWithJSON(w, http.StatusOK, dto.NewHealthCheckResponse("healthy", getVersion(), nil), failedEncodeHealthCheckErrMsg)
-	h.logger.Info("Health check successful")
+	respondWithJSON(w, http.StatusOK, dto.NewHealthCheckResponse(dto.HealthStatusHealthy, getVersion(), nil), failedEncodeHealthCheckErrMsg)
+	h.logger.Debug("Health check successful")
 }
 
 func getVersion() string {

--- a/internal/handlers/health_check_handler.go
+++ b/internal/handlers/health_check_handler.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/fortega2/real-time-chat/internal/dto"
+)
+
+func (h *Handler) HealthCheck(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if ctx.Err() != nil {
+		h.logger.Error(reqCtxErrMsg, "error", ctx.Err())
+		http.Error(w, reqCtxCancelledOrTimedOutErrMsg, http.StatusRequestTimeout)
+		return
+	}
+
+	if err := h.db.PingContext(ctx); err != nil {
+		h.logger.Error("Database ping failed", "error", err)
+		respondWithJSON(w, http.StatusServiceUnavailable, dto.NewHealthCheckResponse("unhealthy", getVersion(), err), failedEncodeHealthCheckErrMsg)
+		return
+	}
+
+	respondWithJSON(w, http.StatusOK, dto.NewHealthCheckResponse("healthy", getVersion(), nil), failedEncodeHealthCheckErrMsg)
+	h.logger.Info("Health check successful")
+}
+
+func getVersion() string {
+	if version := os.Getenv("APP_VERSION"); version != "" {
+		return version
+	}
+	return "1.0.0"
+}

--- a/internal/handlers/health_check_handler_test.go
+++ b/internal/handlers/health_check_handler_test.go
@@ -1,0 +1,201 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/fortega2/real-time-chat/internal/dto"
+	"github.com/fortega2/real-time-chat/internal/handlers"
+	"github.com/fortega2/real-time-chat/internal/repository"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	pathHealthCheck = "/health"
+)
+
+func TestHealthCheck(t *testing.T) {
+	testCases := []struct {
+		name           string
+		setup          func(t *testing.T) (*handlers.Handler, func())
+		expectedStatus int
+		expectedHealth string
+	}{
+		{
+			name: "Healthy Database",
+			setup: func(t *testing.T) (*handlers.Handler, func()) {
+				db := initializeTestDB(t)
+				queries := repository.New(db)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
+				return h, func() { db.Close() }
+			},
+			expectedStatus: http.StatusOK,
+			expectedHealth: "healthy",
+		},
+		{
+			name: "Unhealthy Database - Closed Connection",
+			setup: func(t *testing.T) (*handlers.Handler, func()) {
+				db := initializeTestDB(t)
+				queries := repository.New(db)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
+				db.Close()
+				return h, func() {
+					// No-op teardown since DB is already closed
+				}
+			},
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedHealth: "unhealthy",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, teardown := tc.setup(t)
+			defer teardown()
+
+			req := httptest.NewRequest(http.MethodGet, pathHealthCheck, nil)
+			w := httptest.NewRecorder()
+
+			h.HealthCheck(w, req)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.expectedStatus {
+				t.Errorf(expectedStatusErrMsg, tc.expectedStatus, resp.StatusCode)
+			}
+
+			if resp.Header.Get(headerContentType) != mimeApplicationJSON {
+				t.Errorf(contentTypeErrFmt, resp.Header.Get(headerContentType))
+			}
+
+			checkHealthCheckResponse(t, w, tc.expectedHealth)
+		})
+	}
+}
+
+func TestHealthCheckWithCancelledContext(t *testing.T) {
+	db := initializeTestDB(t)
+	defer db.Close()
+	queries := repository.New(db)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	req := httptest.NewRequest(http.MethodGet, pathHealthCheck, nil)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.HealthCheck(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestTimeout {
+		t.Errorf(expectedStatusErrMsg, http.StatusRequestTimeout, resp.StatusCode)
+	}
+}
+
+func TestHealthCheckVersion(t *testing.T) {
+	testCases := []struct {
+		name            string
+		envVersion      string
+		expectedVersion string
+	}{
+		{
+			name:            "With APP_VERSION environment variable",
+			envVersion:      "2.1.0",
+			expectedVersion: "2.1.0",
+		},
+		{
+			name:            "Without APP_VERSION environment variable",
+			envVersion:      "",
+			expectedVersion: "1.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalVersion := os.Getenv("APP_VERSION")
+			defer os.Setenv("APP_VERSION", originalVersion)
+
+			if tc.envVersion == "" {
+				os.Unsetenv("APP_VERSION")
+			} else {
+				os.Setenv("APP_VERSION", tc.envVersion)
+			}
+
+			db := initializeTestDB(t)
+			defer db.Close()
+			queries := repository.New(db)
+			h := handlers.NewHandler(getMockLogger(), queries, db)
+
+			req := httptest.NewRequest(http.MethodGet, pathHealthCheck, nil)
+			w := httptest.NewRecorder()
+
+			h.HealthCheck(w, req)
+
+			resp := w.Result()
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf(expectedStatusErrMsg, http.StatusOK, resp.StatusCode)
+			}
+
+			checkHealthCheckVersionResponse(t, w, tc.expectedVersion)
+		})
+	}
+}
+
+func checkHealthCheckResponse(t *testing.T, recorder *httptest.ResponseRecorder, expectedStatus string) {
+	t.Helper()
+
+	if recorder == nil {
+		t.Fatal("Expected non-nil *httptest.ResponseRecorder")
+	}
+
+	var response dto.HealthCheckResponseDTO
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode health check response: %v", err)
+	}
+
+	if response.Status != expectedStatus {
+		t.Errorf("Expected status %s, got %s", expectedStatus, response.Status)
+	}
+
+	if response.Version == "" {
+		t.Error("Expected version to be non-empty")
+	}
+
+	if expectedStatus == "unhealthy" && response.Error == "" {
+		t.Error("Expected error message for unhealthy status")
+	}
+
+	if expectedStatus == "healthy" && response.Error != "" {
+		t.Errorf("Expected no error for healthy status, got: %s", response.Error)
+	}
+}
+
+func checkHealthCheckVersionResponse(t *testing.T, body interface{}, expectedVersion string) {
+	t.Helper()
+
+	recorder, ok := body.(*httptest.ResponseRecorder)
+	if !ok {
+		t.Fatal("Expected *httptest.ResponseRecorder")
+	}
+
+	var response dto.HealthCheckResponseDTO
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode health check response: %v", err)
+	}
+
+	if response.Version != expectedVersion {
+		t.Errorf("Expected version %s, got %s", expectedVersion, response.Version)
+	}
+}

--- a/internal/handlers/health_check_handler_test.go
+++ b/internal/handlers/health_check_handler_test.go
@@ -165,7 +165,7 @@ func checkHealthCheckResponse(t *testing.T, recorder *httptest.ResponseRecorder,
 		t.Fatalf("Failed to decode health check response: %v", err)
 	}
 
-	if response.Status != expectedStatus {
+	if response.Status != dto.HealthStatus(expectedStatus) {
 		t.Errorf("Expected status %s, got %s", expectedStatus, response.Status)
 	}
 

--- a/internal/handlers/message_handler_test.go
+++ b/internal/handlers/message_handler_test.go
@@ -27,7 +27,7 @@ func TestGetHistoryMessagesByChannel(t *testing.T) {
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithMessages(t)
 				queries := repository.New(db)
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			expectedStatus: http.StatusOK,
@@ -38,7 +38,7 @@ func TestGetHistoryMessagesByChannel(t *testing.T) {
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDB(t)
 				queries := repository.New(db)
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -49,7 +49,7 @@ func TestGetHistoryMessagesByChannel(t *testing.T) {
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDB(t)
 				queries := repository.New(db)
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			expectedStatus: http.StatusBadRequest,
@@ -60,7 +60,7 @@ func TestGetHistoryMessagesByChannel(t *testing.T) {
 			setup: func(t *testing.T) (*handlers.Handler, func()) {
 				db := initializeTestDBWithMessages(t)
 				queries := repository.New(db)
-				h := handlers.NewHandler(getMockLogger(), queries)
+				h := handlers.NewHandler(getMockLogger(), queries, db)
 				return h, func() { db.Close() }
 			},
 			expectedStatus: http.StatusOK,
@@ -106,7 +106,7 @@ func TestGetHistoryMessagesByChannelWithCustomLimit(t *testing.T) {
 	db := initializeTestDBWithMessages(t)
 	defer db.Close()
 	queries := repository.New(db)
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 
 	req := httptest.NewRequest(http.MethodGet, "/channels/1/messages", nil)
 	w := httptest.NewRecorder()
@@ -134,7 +134,7 @@ func TestGetHistoryMessagesByChannelInvalidLimit(t *testing.T) {
 	db := initializeTestDBWithMessages(t)
 	defer db.Close()
 	queries := repository.New(db)
-	h := handlers.NewHandler(getMockLogger(), queries)
+	h := handlers.NewHandler(getMockLogger(), queries, db)
 
 	req := httptest.NewRequest(http.MethodGet, "/channels/1/messages", nil)
 	w := httptest.NewRecorder()

--- a/internal/server/server-type.go
+++ b/internal/server/server-type.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"net/http"
 
 	"github.com/fortega2/real-time-chat/internal/logger"
@@ -10,5 +11,6 @@ import (
 type Server struct {
 	logger  logger.Logger
 	queries *repository.Queries
+	db      *sql.DB
 	server  *http.Server
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,15 +1,20 @@
 package server_test
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/fortega2/real-time-chat/internal/logger"
 	"github.com/fortega2/real-time-chat/internal/server"
+
+	_ "github.com/mattn/go-sqlite3"
 )
 
 func TestNewServer(t *testing.T) {
+	db := initializeTestDB(t)
+	defer db.Close()
 	mockLogger := logger.NewMockLogger()
-	srv := server.NewServer(mockLogger, nil)
+	srv := server.NewServer(mockLogger, nil, db)
 
 	if srv == nil {
 		t.Fatal("Expected server to be created, got nil")
@@ -17,7 +22,9 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestNewServerWithNilLogger(t *testing.T) {
-	srv := server.NewServer(nil, nil)
+	db := initializeTestDB(t)
+	defer db.Close()
+	srv := server.NewServer(nil, nil, db)
 
 	if srv == nil {
 		t.Fatal("Expected server to be created with nil logger, got nil")
@@ -26,9 +33,21 @@ func TestNewServerWithNilLogger(t *testing.T) {
 
 func TestNewServerWithNilQueries(t *testing.T) {
 	mockLogger := logger.NewMockLogger()
-	srv := server.NewServer(mockLogger, nil)
+	db := initializeTestDB(t)
+	defer db.Close()
+	srv := server.NewServer(mockLogger, nil, db)
 
 	if srv == nil {
 		t.Fatal("Expected server to be created with nil queries, got nil")
 	}
+}
+
+func initializeTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("Failed to open in-memory database: %v", err)
+	}
+
+	return db
 }


### PR DESCRIPTION
This pull request introduces a robust health check endpoint to the application, improves deployment reliability, and enhances security headers in the Traefik configuration. It also updates handler and test code to support the new health check functionality and ensures the application can be monitored and rolled back automatically if unhealthy. Below are the most important changes grouped by theme:

**Health Check Endpoint Implementation**

* Added a new health check handler (`HealthCheck`) in `internal/handlers/health_check_handler.go`, which verifies database connectivity and returns application health status and version.
* Introduced `HealthCheckResponseDTO` and related types in `internal/dto/health_check_dto.go` to standardize health check responses.
* Updated the main server and handler constructors to accept a database reference, enabling health check logic. [[1]](diffhunk://#diff-1007929257c546326a7a7733ed8f396eb73b40d26dbedda5de2c7c06c724ccf6L41-R41) [[2]](diffhunk://#diff-470903a14cd8be3f49c8831e2b7b42a05d4bcff4cc707f94227a3ab7570f6775R4-R5) [[3]](diffhunk://#diff-470903a14cd8be3f49c8831e2b7b42a05d4bcff4cc707f94227a3ab7570f6775R22-R36)

**Deployment and Monitoring Enhancements**

* Added a Docker health check to the main `Dockerfile` and service definitions in `docker-compose.yml` and `docker-compose.dev.yml`, allowing automated health monitoring via HTTP. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R43-R46) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R58-R70) [[3]](diffhunk://#diff-9542f82d64bbeebd91f6236324bfe199e9657e2cb1fd9779d5d6dcdcf9cd4de1R56-R61)
* Modified the deployment workflow (`.github/workflows/deploy-app.yml`) to copy the updated `docker-compose.yml` to the VM and wait for the application to become healthy post-deployment, with automatic rollback if unhealthy. [[1]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581R20-R23) [[2]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581R43-R60)

**Security Improvements**

* Strengthened Traefik security headers by adding `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` to the middleware configuration in `docker-compose.yml`.

**Test and Handler Refactoring**

* Refactored handler initialization in `internal/handlers/channel_handler_test.go` to include the database reference, ensuring tests are compatible with the new health check logic. [[1]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L40-R40) [[2]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L105-R105) [[3]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L115-R115) [[4]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L125-R125) [[5]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L135-R135) [[6]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L145-R145) [[7]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L155-R155) [[8]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L175-R175) [[9]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L185-R185) [[10]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L226-R226) [[11]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L246-R246) [[12]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L352-R352) [[13]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L368-R368) [[14]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L401-R407) [[15]](diffhunk://#diff-d814a29405ca68a3bc5884ba9dcbc1e3403aadc73c70e93fc96748ca64a5ebe0L506-R506)

**Dependency Updates**

* Added `curl` to the runtime image in the `Dockerfile` to support health checks.